### PR TITLE
Display readable unit when dumping data blocks

### DIFF
--- a/components/mbus_controller/mbus_controller.cpp
+++ b/components/mbus_controller/mbus_controller.cpp
@@ -2,6 +2,9 @@
 
 #include "mbus_controller.h"
 
+#include <map>
+#include <string>
+
 #include "esphome/core/log.h"
 #include "esp_err.h"
 #include <freertos/FreeRTOS.h>
@@ -12,13 +15,37 @@
 #include "mbus_reader.h"
 #include "pwm.h"
 
-using namespace std; 
+using namespace std;
 
 namespace esphome
 {
   namespace mbus_controller
   {
     static const char *TAG = "MbusController";
+
+    map<MbusReader::Unit, string> MbusController::unit_names_ = {
+      { MbusReader::Unit::WH, "Wh" },
+      { MbusReader::Unit::J, "J" },
+      { MbusReader::Unit::CUBIC_METER, "m3" },
+      { MbusReader::Unit::KG, "kg" },
+      { MbusReader::Unit::SECONDS, "s" },
+      { MbusReader::Unit::MINUTES, "min" },
+      { MbusReader::Unit::HOURS, "h" },
+      { MbusReader::Unit::DAYS, "days" },
+      { MbusReader::Unit::W, "W" },
+      { MbusReader::Unit::J_PER_HOUR, "J/h" },
+      { MbusReader::Unit::CUBIC_METER_PER_HOUR, "m3/h" },
+      { MbusReader::Unit::CUBIC_METER_PER_MINUTE, "m3/min" },
+      { MbusReader::Unit::CUBIC_METER_PER_SECOND, "m3/s" },
+      { MbusReader::Unit::KG_PER_HOUR, "kg/h" },
+      { MbusReader::Unit::DEGREES_CELSIUS, "deg c" },
+      { MbusReader::Unit::K, "K" },
+      { MbusReader::Unit::BAR, "bar" },
+      { MbusReader::Unit::DATE, "date" },
+      { MbusReader::Unit::TIME_AND_DATE, "time and date" },
+      { MbusReader::Unit::MANUFACTURER_SPECIFIC, "manuf. specific" },
+      { MbusReader::Unit::DIMENSIONLESS, "-" }
+    };
 
     bool pwm_initialized { false };
     bool pwm_enabled { false };
@@ -129,7 +156,7 @@ namespace esphome
         ESP_LOGI(TAG, "-- Index:\t\t\t%d --", data_block->index);
         ESP_LOGI(TAG, "Function:\t\t\t%d", data_block->function);
         ESP_LOGI(TAG, "Storage number:\t\t%d", data_block->storage_number);
-        ESP_LOGI(TAG, "Unit:\t\t\t%d", data_block->unit);
+        ESP_LOGI(TAG, "Unit:\t\t\t%s", MbusController::unit_names_[data_block->unit].c_str());
         ESP_LOGI(TAG, "Ten power:\t\t\t%d", data_block->ten_power);
         ESP_LOGI(TAG, "Data length:\t\t%d", data_block->data_length);
         ESP_LOGI(TAG, "-------------------------------");

--- a/components/mbus_controller/mbus_controller.cpp
+++ b/components/mbus_controller/mbus_controller.cpp
@@ -47,6 +47,13 @@ namespace esphome
       { MbusReader::Unit::DIMENSIONLESS, "-" }
     };
 
+    map<MbusReader::Function, string> MbusController::function_names_ = {
+      { MbusReader::Function::INSTANTANEOUS, "instantaneous" },
+      { MbusReader::Function::MAXIMUM, "maximum" },
+      { MbusReader::Function::MINIMUM, "minimum" },
+      { MbusReader::Function::DURING_ERROR_STATE, "during error state" }
+    };
+
     bool pwm_initialized { false };
     bool pwm_enabled { false };
 
@@ -154,7 +161,7 @@ namespace esphome
     void MbusController::dump_data_blocks(MbusReader::MbusMeterData* meter_data) {
       for (auto data_block : *(meter_data->data_blocks)) {
         ESP_LOGI(TAG, "-- Index:\t\t\t%d --", data_block->index);
-        ESP_LOGI(TAG, "Function:\t\t\t%d", data_block->function);
+        ESP_LOGI(TAG, "Function:\t\t\t%s", MbusController::function_names_[data_block->function].c_str());
         ESP_LOGI(TAG, "Storage number:\t\t%d", data_block->storage_number);
         ESP_LOGI(TAG, "Unit:\t\t\t%s", MbusController::unit_names_[data_block->unit].c_str());
         ESP_LOGI(TAG, "Ten power:\t\t\t%d", data_block->ten_power);

--- a/components/mbus_controller/mbus_controller.h
+++ b/components/mbus_controller/mbus_controller.h
@@ -43,6 +43,7 @@ class MbusController : public Component, public uart::UARTDevice {
   bool mbus_enabled_ { true };
   std::vector<IMbusSensor*> sensors_;
   static std::map<MbusReader::Unit, std::string> unit_names_;
+  static std::map<MbusReader::Function, std::string> function_names_;
 
  private:
   static void read_mbus_task_loop(void* params);

--- a/components/mbus_controller/mbus_controller.h
+++ b/components/mbus_controller/mbus_controller.h
@@ -1,6 +1,8 @@
 #ifndef MBUS_CONTROLLER_H_
 #define MBUS_CONTROLLER_H_
 
+#include <map>
+#include <string>
 #include <vector>
 
 #include "esphome/components/uart/uart.h"
@@ -40,6 +42,7 @@ class MbusController : public Component, public uart::UARTDevice {
   bool update_requested_ { false };
   bool mbus_enabled_ { true };
   std::vector<IMbusSensor*> sensors_;
+  static std::map<MbusReader::Unit, std::string> unit_names_;
 
  private:
   static void read_mbus_task_loop(void* params);

--- a/kamstrup_data_blocks.txt
+++ b/kamstrup_data_blocks.txt
@@ -1,146 +1,146 @@
 Successfully read meter data
 -- Index:                    0 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        Wh
 Ten power:                   3
 Data length:         4
 -------------------------------
 -- Index:                    1 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        m3
 Ten power:                   -2
 Data length:         4
 -------------------------------
 -- Index:                    2 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        manuf. specific
 Ten power:                   0
 Data length:         4
 -------------------------------
 -- Index:                    3 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        manuf. specific
 Ten power:                   0
 Data length:         4
 -------------------------------
 -- Index:                    4 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        h
 Ten power:                   0
 Data length:         3
 -------------------------------
 -- Index:                    5 --
-Function:                    3
+Function:                    during error state
 Storage number:              0
 Unit:                        h
 Ten power:                   0
 Data length:         3
 -------------------------------
 -- Index:                    6 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        deg c
 Ten power:                   -2
 Data length:         2
 -------------------------------
 -- Index:                    7 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        deg c
 Ten power:                   -2
 Data length:         2
 -------------------------------
 -- Index:                    8 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        K
 Ten power:                   -2
 Data length:         2
 -------------------------------
 -- Index:                    9 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        W
 Ten power:                   2
 Data length:         2
 -------------------------------
 -- Index:                    10 --
-Function:                    1
+Function:                    maximum
 Storage number:              0
 Unit:                        W
 Ten power:                   2
 Data length:         2
 -------------------------------
 -- Index:                    11 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        m3/h
 Ten power:                   -3
 Data length:         2
 -------------------------------
 -- Index:                    12 --
-Function:                    1
+Function:                    maximum
 Storage number:              0
 Unit:                        m3/h
 Ten power:                   -3
 Data length:         2
 -------------------------------
 -- Index:                    13 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              0
 Unit:                        manuf. specific
 Ten power:                   0
 Data length:         2
 -------------------------------
 -- Index:                    14 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              1
 Unit:                        Wh
 Ten power:                   3
 Data length:         4
 -------------------------------
 -- Index:                    15 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              1
 Unit:                        m3
 Ten power:                   -2
 Data length:         4
 -------------------------------
 -- Index:                    16 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              1
 Unit:                        manuf. specific
 Ten power:                   0
 Data length:         4
 -------------------------------
 -- Index:                    17 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              1
 Unit:                        manuf. specific
 Ten power:                   0
 Data length:         4
 -------------------------------
 -- Index:                    18 --
-Function:                    1
+Function:                    maximum
 Storage number:              1
 Unit:                        W
 Ten power:                   2
 Data length:         2
 -------------------------------
 -- Index:                    19 --
-Function:                    1
+Function:                    maximum
 Storage number:              1
 Unit:                        m3/h
 Ten power:                   -3
 Data length:         2
 -------------------------------
 -- Index:                    20 --
-Function:                    0
+Function:                    instantaneous
 Storage number:              1
 Unit:                        date
 Ten power:                   0

--- a/kamstrup_data_blocks.txt
+++ b/kamstrup_data_blocks.txt
@@ -1,147 +1,148 @@
--- Index:              0 --
-Function:              0
-Storage number:        0
-Unit:                  0
-Ten power:             3
-Data length:           4
-----------------------------
--- Index:              1 --
-Function:              0
-Storage number:        0
-Unit:                  2
-Ten power:             -2
-Data length:           4
-----------------------------
--- Index:              2 --
-Function:              0
-Storage number:        0
-Unit:                  19
-Ten power:             0
-Data length:           4
-----------------------------
--- Index:              3 --
-Function:              0
-Storage number:        0
-Unit:                  19
-Ten power:             0
-Data length:           4
-----------------------------
--- Index:              4 --
-Function:              0
-Storage number:        0
-Unit:                  6
-Ten power:             0
-Data length:           3
-----------------------------
--- Index:              5 --
-Function:              3
-Storage number:        0
-Unit:                  6
-Ten power:             0
-Data length:           3
-----------------------------
--- Index:              6 --
-Function:              0
-Storage number:        0
-Unit:                  14
-Ten power:             -2
-Data length:           2
-----------------------------
--- Index:              7 --
-Function:              0
-Storage number:        0
-Unit:                  14
-Ten power:             -2
-Data length:           2
-----------------------------
--- Index:              8 --
-Function:              0
-Storage number:        0
-Unit:                  15
-Ten power:             -2
-Data length:           2
-----------------------------
--- Index:              9 --
-Function:              0
-Storage number:        0
-Unit:                  8
-Ten power:             2
-Data length:           2
-----------------------------
--- Index:              10 --
-Function:              1
-Storage number:        0
-Unit:                  8
-Ten power:             2
-Data length:           2
-----------------------------
--- Index:              11 --
-Function:              0
-Storage number:        0
-Unit:                  10
-Ten power:             -3
-Data length:           2
-----------------------------
--- Index:              12 --
-Function:              1
-Storage number:        0
-Unit:                  10
-Ten power:             -3
-Data length:           2
-----------------------------
--- Index:              13 --
-Function:              0
-Storage number:        0
-Unit:                  19
-Ten power:             0
-Data length:           2
-----------------------------
--- Index:              14 --
-Function:              0
-Storage number:        1
-Unit:                  0
-Ten power:             3
-Data length:           4
-----------------------------
--- Index:              15 --
-Function:              0
-Storage number:        1
-Unit:                  2
-Ten power:             -2
-Data length:           4
-----------------------------
--- Index:              16 --
-Function:              0
-Storage number:        1
-Unit:                  19
-Ten power:             0
-Data length:           4
-----------------------------
--- Index:              17 --
-Function:              0
-Storage number:        1
-Unit:                  19
-Ten power:             0
-Data length:           4
-----------------------------
--- Index:              18 --
-Function:              1
-Storage number:        1
-Unit:                  8
-Ten power:             2
-Data length:           2
-----------------------------
--- Index:              19 --
-Function:              1
-Storage number:        1
-Unit:                  10
-Ten power:             -3
-Data length:           2
-----------------------------
--- Index:              20 --
-Function:              0
-Storage number:        1
-Unit:                  17
-Ten power:             0
-Data length:           2
-----------------------------
+Successfully read meter data
+-- Index:                    0 --
+Function:                    0
+Storage number:              0
+Unit:                        Wh
+Ten power:                   3
+Data length:         4
+-------------------------------
+-- Index:                    1 --
+Function:                    0
+Storage number:              0
+Unit:                        m3
+Ten power:                   -2
+Data length:         4
+-------------------------------
+-- Index:                    2 --
+Function:                    0
+Storage number:              0
+Unit:                        manuf. specific
+Ten power:                   0
+Data length:         4
+-------------------------------
+-- Index:                    3 --
+Function:                    0
+Storage number:              0
+Unit:                        manuf. specific
+Ten power:                   0
+Data length:         4
+-------------------------------
+-- Index:                    4 --
+Function:                    0
+Storage number:              0
+Unit:                        h
+Ten power:                   0
+Data length:         3
+-------------------------------
+-- Index:                    5 --
+Function:                    3
+Storage number:              0
+Unit:                        h
+Ten power:                   0
+Data length:         3
+-------------------------------
+-- Index:                    6 --
+Function:                    0
+Storage number:              0
+Unit:                        deg c
+Ten power:                   -2
+Data length:         2
+-------------------------------
+-- Index:                    7 --
+Function:                    0
+Storage number:              0
+Unit:                        deg c
+Ten power:                   -2
+Data length:         2
+-------------------------------
+-- Index:                    8 --
+Function:                    0
+Storage number:              0
+Unit:                        K
+Ten power:                   -2
+Data length:         2
+-------------------------------
+-- Index:                    9 --
+Function:                    0
+Storage number:              0
+Unit:                        W
+Ten power:                   2
+Data length:         2
+-------------------------------
+-- Index:                    10 --
+Function:                    1
+Storage number:              0
+Unit:                        W
+Ten power:                   2
+Data length:         2
+-------------------------------
+-- Index:                    11 --
+Function:                    0
+Storage number:              0
+Unit:                        m3/h
+Ten power:                   -3
+Data length:         2
+-------------------------------
+-- Index:                    12 --
+Function:                    1
+Storage number:              0
+Unit:                        m3/h
+Ten power:                   -3
+Data length:         2
+-------------------------------
+-- Index:                    13 --
+Function:                    0
+Storage number:              0
+Unit:                        manuf. specific
+Ten power:                   0
+Data length:         2
+-------------------------------
+-- Index:                    14 --
+Function:                    0
+Storage number:              1
+Unit:                        Wh
+Ten power:                   3
+Data length:         4
+-------------------------------
+-- Index:                    15 --
+Function:                    0
+Storage number:              1
+Unit:                        m3
+Ten power:                   -2
+Data length:         4
+-------------------------------
+-- Index:                    16 --
+Function:                    0
+Storage number:              1
+Unit:                        manuf. specific
+Ten power:                   0
+Data length:         4
+-------------------------------
+-- Index:                    17 --
+Function:                    0
+Storage number:              1
+Unit:                        manuf. specific
+Ten power:                   0
+Data length:         4
+-------------------------------
+-- Index:                    18 --
+Function:                    1
+Storage number:              1
+Unit:                        W
+Ten power:                   2
+Data length:         2
+-------------------------------
+-- Index:                    19 --
+Function:                    1
+Storage number:              1
+Unit:                        m3/h
+Ten power:                   -3
+Data length:         2
+-------------------------------
+-- Index:                    20 --
+Function:                    0
+Storage number:              1
+Unit:                        date
+Ten power:                   0
+Data length:         2
+-------------------------------


### PR DESCRIPTION
Show readable units when dumping data blocks after the first read-out since enabling.